### PR TITLE
Add S2S name and roles for Immigration & Asylum service

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,8 +42,8 @@ info:
 #    version: ${PACKAGES_VERSION:unknown}
 
 authorization:
-  case-worker-roles: ${CASE_WORKER_ROLES:caseworker-probate,caseworker-cmc,caseworker-sscs,caseworker-divorce}
-  s2s-names-whitelist: ${S2S_NAMES_WHITELIST:sscs,divorce,ccd,em_gw,jui_webapp,pui_webapp,ccd_data}
+  case-worker-roles: ${CASE_WORKER_ROLES:caseworker-probate,caseworker-cmc,caseworker-sscs,caseworker-divorce,caseworker-ia}
+  s2s-names-whitelist: ${S2S_NAMES_WHITELIST:sscs,divorce,ccd,em_gw,jui_webapp,pui_webapp,ccd_data,iac}
 
 auth:
   idam:


### PR DESCRIPTION
### JIRA link (if applicable) ###

Part of this work:
https://tools.hmcts.net/jira/browse/RIA-941

### Change description ###

Added Immigration & Asylum service name and caseworker role.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
