### PR TITLE
EM1464 - toggleable coversheets - don't override ccd ui values

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/endpoint/NewBundleController.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/endpoint/NewBundleController.java
@@ -38,8 +38,6 @@ public class NewBundleController {
             log.error(e.getMessage(), e);
             ccdCallbackResponseDto.getErrors().add(e.getMessage());
         }
-        System.out.println("JJJ - ccd orchestrator is returning this DTO");
-        System.out.println(ccdCallbackResponseDto);
         return ResponseEntity.ok(ccdCallbackResponseDto);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/service/dto/CcdBundleDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/service/dto/CcdBundleDTO.java
@@ -18,8 +18,8 @@ public class CcdBundleDTO {
     @JsonIgnore
     private List<CcdValue<CcdBundleFolderDTO>> folders = new LinkedList<>();
     private String fileName;
-    private CcdBoolean hasTableOfContents = CcdBoolean.Yes;
-    private CcdBoolean hasCoversheets = CcdBoolean.Yes;
+    private CcdBoolean hasTableOfContents;
+    private CcdBoolean hasCoversheets;
 
     public Long getId() {
         return id;

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/stitching/dto/StitchingBundleDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/stitching/dto/StitchingBundleDTO.java
@@ -10,8 +10,8 @@ public class StitchingBundleDTO {
     private List<StitchingBundleFolderDTO> folders = new ArrayList<>();
     private List<StitchingBundleDocumentDTO> documents = new ArrayList<>();
     private String fileName;
-    private boolean hasTableOfContents = true;
-    private boolean hasCoversheets = true;
+    private boolean hasTableOfContents;
+    private boolean hasCoversheets;
 
     public String getBundleTitle() {
         return bundleTitle;


### PR DESCRIPTION
### JIRA link (if applicable) ###
em1464
### Change description ###
even if users set toggle values to No, the default values override this and stitching API receives these as "Yes". I'll test CCD UI with this and if it doesn't work, I'll revert the change.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
