### PR TITLE
valid cloned filename, and set default eligible values

### DIFF
--- a/src/aat/java/uk/gov/hmcts/reform/em/orchestrator/functional/CcdCloneScenarios.java
+++ b/src/aat/java/uk/gov/hmcts/reform/em/orchestrator/functional/CcdCloneScenarios.java
@@ -39,7 +39,7 @@ public class CcdCloneScenarios {
         Assert.assertEquals(200, response.getStatusCode());
         Assert.assertEquals("Bundle title", path.getString("data.caseBundles[0].value.title"));
         Assert.assertEquals("no", path.getString("data.caseBundles[0].value.eligibleForCloning"));
-        Assert.assertEquals("Bundle title - CLONED", path.getString("data.caseBundles[1].value.title"));
+        Assert.assertEquals("CLONED_Bundle title", path.getString("data.caseBundles[1].value.title"));
         Assert.assertEquals("no", path.getString("data.caseBundles[1].value.eligibleForCloning"));
     }
 
@@ -50,7 +50,7 @@ public class CcdCloneScenarios {
 
         CcdBundleDTO bundle2 = testUtil.getTestBundle();
         bundle2.setTitle("Bundle 2");
-        bundle2.setFileName("Filename Bundle 2");
+        bundle2.setFileName("FilenameBundle2");
         bundle2.setEligibleForCloningAsBoolean(true);
 
         List<CcdValue<CcdBundleDTO>> list = new ArrayList<>();
@@ -70,8 +70,8 @@ public class CcdCloneScenarios {
         Assert.assertEquals(200, response.getStatusCode());
         Assert.assertEquals("Bundle 1", path.getString("data.caseBundles[0].value.title"));
         Assert.assertEquals("Bundle 2", path.getString("data.caseBundles[1].value.title"));
-        Assert.assertEquals("Bundle 2 - CLONED", path.getString("data.caseBundles[2].value.title"));
-        Assert.assertEquals("Filename Bundle 2 - CLONED", path.getString("data.caseBundles[2].value.fileName"));
+        Assert.assertEquals("CLONED_Bundle 2", path.getString("data.caseBundles[2].value.title"));
+        Assert.assertEquals("CLONED_FilenameBundle2", path.getString("data.caseBundles[2].value.fileName"));
         Assert.assertEquals("no", path.getString("data.caseBundles[1].value.eligibleForCloning"));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/automatedbundling/AutomatedCaseUpdater.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/automatedbundling/AutomatedCaseUpdater.java
@@ -59,6 +59,8 @@ public class AutomatedCaseUpdater implements CcdCaseUpdater {
         bundle.setHasCoversheets(CcdBoolean.Yes);
         bundle.setHasTableOfContents(CcdBoolean.Yes);
         bundle.setFileName(configuration.filename);
+        bundle.setEligibleForCloningAsBoolean(false);
+        bundle.setEligibleForStitchingAsBoolean(false);
 
         addFolders(configuration.folders, bundle.getFolders(), 0);
 

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/exampleservice/ExampleBundlePopulator.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/exampleservice/ExampleBundlePopulator.java
@@ -23,6 +23,8 @@ public class ExampleBundlePopulator {
         ccdBundleDTO.setFileName("exampleservice-bundle.pdf");
         ccdBundleDTO.setHasCoversheets(CcdBoolean.Yes);
         ccdBundleDTO.setHasTableOfContents(CcdBoolean.Yes);
+        ccdBundleDTO.setEligibleForStitchingAsBoolean(false);
+        ccdBundleDTO.setEligibleForCloningAsBoolean(false);
 
         ArrayNode caseDocuments = (ArrayNode) caseData.findValue("caseDocuments");
 

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/financialremedyservice/FinancialRemedyBundlePopulator.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/financialremedyservice/FinancialRemedyBundlePopulator.java
@@ -3,10 +3,7 @@ package uk.gov.hmcts.reform.em.orchestrator.financialremedyservice;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.em.orchestrator.service.dto.CcdBundleDTO;
-import uk.gov.hmcts.reform.em.orchestrator.service.dto.CcdBundleDocumentDTO;
-import uk.gov.hmcts.reform.em.orchestrator.service.dto.CcdDocument;
-import uk.gov.hmcts.reform.em.orchestrator.service.dto.CcdValue;
+import uk.gov.hmcts.reform.em.orchestrator.service.dto.*;
 
 
 @Service
@@ -21,6 +18,10 @@ public class FinancialRemedyBundlePopulator {
     public JsonNode populateNewBundle(JsonNode caseData) {
         CcdBundleDTO ccdBundleDTO = new CcdBundleDTO();
         ccdBundleDTO.setTitle("New Bundle");
+        ccdBundleDTO.setEligibleForStitchingAsBoolean(false);
+        ccdBundleDTO.setEligibleForCloningAsBoolean(false);
+        ccdBundleDTO.setHasTableOfContents(CcdBoolean.Yes);
+        ccdBundleDTO.setHasCoversheets(CcdBoolean.Yes);
 
         JsonNode scanned4AFormDocument = caseData.findValue("uploadScanned4AForm");
         JsonNode scanned4BFormDocument = caseData.findValue("uploadScanned4BForm");

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/service/caseupdater/CcdBundleCloningService.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/service/caseupdater/CcdBundleCloningService.java
@@ -71,8 +71,8 @@ public class CcdBundleCloningService {
     private JsonNode cloneBundle(JsonNode originalJson) throws IOException {
         JsonNode unprocessedClonedJson = originalJson.deepCopy();
         CcdBundleDTO clonedBundle = bundleJsonToBundleDto(unprocessedClonedJson);
-        clonedBundle.setTitle(clonedBundle.getTitle() + " - CLONED");
-        clonedBundle.setFileName(clonedBundle.getFileName() + " - CLONED");
+        clonedBundle.setTitle("CLONED_" + clonedBundle.getTitle());
+        clonedBundle.setFileName("CLONED_" + clonedBundle.getFileName());
         return bundleDtoToBundleJson(clonedBundle);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/em/orchestrator/service/caseupdater/CcdBundleCloningServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/orchestrator/service/caseupdater/CcdBundleCloningServiceTest.java
@@ -74,7 +74,7 @@ public class CcdBundleCloningServiceTest {
         Assert.assertEquals(2, node.get("case_details").get("case_data").get("caseBundles").size());
         Assert.assertEquals(updatedFirstBundle.getDescription(), updatedSecondBundle.getDescription());
         checkIthBundleTitle(updatedBundles, 0, "First Bundle");
-        checkIthBundleTitle(updatedBundles, 1, "First Bundle - CLONED");
+        checkIthBundleTitle(updatedBundles, 1, "CLONED_First Bundle");
     }
 
     @Test
@@ -132,9 +132,9 @@ public class CcdBundleCloningServiceTest {
 
         Assert.assertEquals(4, node.get("case_details").get("case_data").get("caseBundles").size());
         checkIthBundleTitle(updatedBundles, 0, "First Bundle");
-        checkIthBundleTitle(updatedBundles, 1, "First Bundle - CLONED");
+        checkIthBundleTitle(updatedBundles, 1, "CLONED_First Bundle");
         checkIthBundleTitle(updatedBundles, 2, "Second Bundle");
-        checkIthBundleTitle(updatedBundles, 3, "Second Bundle - CLONED");
+        checkIthBundleTitle(updatedBundles, 3, "CLONED_Second Bundle");
     }
 
     @Test
@@ -153,7 +153,7 @@ public class CcdBundleCloningServiceTest {
 
         Assert.assertEquals(3, node.get("case_details").get("case_data").get("caseBundles").size());
         checkIthBundleTitle(updatedBundles, 0, "First Bundle");
-        checkIthBundleTitle(updatedBundles, 1, "First Bundle - CLONED");
+        checkIthBundleTitle(updatedBundles, 1, "CLONED_First Bundle");
         checkIthBundleTitle(updatedBundles, 2, "Second Bundle");
     }
 


### PR DESCRIPTION
### Change description ###
For create bundle events without a bundleConfiguration set up, it'll set default values for eligibleForCloning and eligibleForStitching to false.
Cloned bundles will have "CLONED_" prefixing the file name and bundle title. This no longer breaks validation requirements 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
