### PR TITLE
Add coversheet options to yaml

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/automatedbundling/configuration/BundleConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/automatedbundling/configuration/BundleConfiguration.java
@@ -11,13 +11,22 @@ public class BundleConfiguration {
 
     public final String title;
     public final String filename;
+    public final boolean hasTableOfContents;
+    public final boolean hasCoversheets;
+    public final boolean hasFolderCoversheets;
     public final List<BundleConfigurationFolder> folders;
 
     public BundleConfiguration(@JsonProperty("title") String title,
-                               @JsonProperty(value = "filename") String filename,
+                               @JsonProperty("filename") String filename,
+                               @JsonProperty("hasTableOfContents") boolean hasTableOfContents,
+                               @JsonProperty("hasCoversheets") boolean hasCoversheets,
+                               @JsonProperty("hasFolderCoversheets") boolean hasFolderCoversheets,
                                @JsonProperty("folders") List<BundleConfigurationFolder> folders) {
         this.title = title;
         this.filename = filename == null ? "stitched.pdf" : filename;
+        this.hasTableOfContents = hasTableOfContents;
+        this.hasCoversheets = hasCoversheets;
+        this.hasFolderCoversheets = hasFolderCoversheets;
         this.folders = folders;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/service/dto/CcdBundleDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/service/dto/CcdBundleDTO.java
@@ -25,6 +25,7 @@ public class CcdBundleDTO {
     private String fileName;
     private CcdBoolean hasTableOfContents;
     private CcdBoolean hasCoversheets;
+    private CcdBoolean hasFolderCoversheets;
     private String stitchStatus;
 
     public Long getId() {
@@ -146,4 +147,13 @@ public class CcdBundleDTO {
     public void setStitchStatus(String stitchStatus) {
         this.stitchStatus = stitchStatus;
     }
+
+    public CcdBoolean getHasFolderCoversheets() {
+        return hasFolderCoversheets;
+    }
+
+    public void setHasFolderCoversheets(CcdBoolean hasFolderCoversheets) {
+        this.hasFolderCoversheets = hasFolderCoversheets;
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/stitching/dto/StitchingBundleDTO.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/stitching/dto/StitchingBundleDTO.java
@@ -12,6 +12,7 @@ public class StitchingBundleDTO {
     private String fileName;
     private boolean hasTableOfContents;
     private boolean hasCoversheets;
+    private boolean hasFolderCoversheets;
 
     public String getBundleTitle() {
         return bundleTitle;
@@ -68,5 +69,14 @@ public class StitchingBundleDTO {
     public void setHasCoversheets(boolean hasCoversheets) {
         this.hasCoversheets = hasCoversheets;
     }
+
+    public boolean getHasFolderCoversheets() {
+        return hasFolderCoversheets;
+    }
+
+    public void setHasFolderCoversheets(boolean hasFolderCoversheets) {
+        this.hasFolderCoversheets = hasFolderCoversheets;
+    }
+
 }
 

--- a/src/main/java/uk/gov/hmcts/reform/em/orchestrator/stitching/mapper/StitchingDTOMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/em/orchestrator/stitching/mapper/StitchingDTOMapper.java
@@ -18,6 +18,7 @@ public class StitchingDTOMapper {
         bundle.setFileName(bundleDTO.getFileName());
         bundle.setHasTableOfContents(bundleDTO.getHasTableOfContents() == CcdBoolean.Yes);
         bundle.setHasCoversheets(bundleDTO.getHasCoversheets() == CcdBoolean.Yes);
+        bundle.setHasFolderCoversheets(bundleDTO.getHasFolderCoversheets() == CcdBoolean.Yes);
         bundle.setDocuments(getDocuments(bundleDTO.getDocuments()));
         bundle.setFolders(getFolders(bundleDTO.getFolders()));
 

--- a/src/main/resources/bundleconfiguration/example-with-filename.yaml
+++ b/src/main/resources/bundleconfiguration/example-with-filename.yaml
@@ -1,5 +1,8 @@
 title: Bundle with filename
 filename: bundle.pdf
+hasTableOfContents: false
+hasCoversheets: false
+hasFolderCoversheets: true
 folders:
   - name: Folder 1
   - name: Folder 2

--- a/src/main/resources/bundleconfiguration/example.yaml
+++ b/src/main/resources/bundleconfiguration/example.yaml
@@ -1,4 +1,6 @@
 title: New bundle
+hasCoversheets: true
+hasTableOfContents: true
 folders:
   - name: Folder 1
     folders:

--- a/src/test/java/uk/gov/hmcts/reform/em/orchestrator/automatedbundling/configuration/LocalConfigurationLoaderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/orchestrator/automatedbundling/configuration/LocalConfigurationLoaderTest.java
@@ -14,6 +14,9 @@ public class LocalConfigurationLoaderTest {
         BundleConfiguration config = loader.load("example.yaml");
 
         assertEquals(config.title, "New bundle");
+        assertEquals(config.hasTableOfContents, true);
+        assertEquals(config.hasCoversheets, true);
+        assertEquals(config.hasFolderCoversheets, false);
         assertEquals(config.folders.get(0).name, "Folder 1");
         assertEquals(config.folders.get(0).folders.get(0).name, "Folder 1.a");
         assertEquals(config.folders.get(0).folders.get(1).name, "Folder 1.b");
@@ -32,5 +35,9 @@ public class LocalConfigurationLoaderTest {
 
         assertEquals(config.title, "Bundle with filename");
         assertEquals(config.filename, "bundle.pdf");
+        assertEquals(config.hasTableOfContents, false);
+        assertEquals(config.hasCoversheets, false);
+        assertEquals(config.hasFolderCoversheets, true);
+
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/em/orchestrator/stitching/mapper/StitchingDTOMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/em/orchestrator/stitching/mapper/StitchingDTOMapperTest.java
@@ -34,6 +34,7 @@ public class StitchingDTOMapperTest {
         bundleDTO.setFileName("a-file.pdf");
         bundleDTO.setHasCoversheets(CcdBoolean.No);
         bundleDTO.setHasTableOfContents(CcdBoolean.Yes);
+        bundleDTO.setHasFolderCoversheets(CcdBoolean.No);
         bundleDTO.getDocuments().add(new CcdValue<>(document1DTO));
         bundleDTO.getFolders().add(new CcdValue<>(folder1DTO));
         bundleDTO.getFolders().add(new CcdValue<>(folder3DTO));
@@ -46,6 +47,7 @@ public class StitchingDTOMapperTest {
         assertEquals(bundleDTO.getFileName(), stitchingBundleDTO.getFileName());
         assertEquals(bundleDTO.getHasCoversheets() == CcdBoolean.Yes, stitchingBundleDTO.getHasCoversheets());
         assertEquals(bundleDTO.getHasTableOfContents() == CcdBoolean.Yes, stitchingBundleDTO.getHasTableOfContents());
+        assertEquals(bundleDTO.getHasFolderCoversheets() == CcdBoolean.Yes, stitchingBundleDTO.getHasFolderCoversheets());
 
         assertEquals(
                 bundleDTO.getDocuments().get(0).getValue().getSourceDocument().getUrl(),


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EM-1810
https://tools.hmcts.net/jira/browse/EM-1811

### Change description ###

Update CCD orchestrator to have the hasFolderCoversheet option and support loading from yaml file

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
